### PR TITLE
Make the crate usable for external projects

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0 OR BSD-3-Clause"
 edition = "2018"
 
 [dependencies]
-byteorder = "~1.2.1"
+byteorder = ">=1.2.1"
 log = "0.4"
 kvm-bindings = "~0"
 kvm-ioctls = "~0"

--- a/src/vfio_device.rs
+++ b/src/vfio_device.rs
@@ -345,7 +345,7 @@ impl VfioContainer {
     ///
     /// # Parameters
     /// * mem: pinned guest memory which could be accessed by devices binding to the container.
-    pub fn vfio_map_guest_memory(&self, mem: GuestMemoryMmap) -> Result<()> {
+    pub fn vfio_map_guest_memory(&self, mem: &GuestMemoryMmap) -> Result<()> {
         mem.with_regions(|_index, region| {
             self.vfio_dma_map(
                 region.start_addr().raw_value(),
@@ -363,7 +363,7 @@ impl VfioContainer {
     ///
     /// # Parameters
     /// * mem: pinned guest memory which could be accessed by devices binding to the container.
-    pub fn vfio_unmap_guest_memory(&self, mem: GuestMemoryMmap) -> Result<()> {
+    pub fn vfio_unmap_guest_memory(&self, mem: &GuestMemoryMmap) -> Result<()> {
         mem.with_regions(|_index, region| {
             self.vfio_dma_unmap(region.start_addr().raw_value(), region.len() as u64)
         })?;


### PR DESCRIPTION
This PR brings a few changes so that external projects such as Cloud Hypervisor can pull directly from this crate.