### PR TITLE
Fix disabling IRQs

### DIFF
--- a/src/vfio_device.rs
+++ b/src/vfio_device.rs
@@ -99,7 +99,7 @@ impl fmt::Display for VfioError {
                 write!(f, "failed to remove guest memory map from iommu table")
             }
             VfioError::VfioDeviceGetIrqInfo => write!(f, "failed to get vfio device irq info"),
-            VfioError::VfioDeviceSetIrq => write!(f, "failed to set vfio deviece irq"),
+            VfioError::VfioDeviceSetIrq => write!(f, "failed to set vfio device irq"),
         }
     }
 }

--- a/src/vfio_device.rs
+++ b/src/vfio_device.rs
@@ -803,12 +803,14 @@ impl VfioDevice {
             return Err(VfioError::VfioDeviceSetIrq);
         }
 
+        // Individual subindex interrupts can be disabled using the -1 value for DATA_EVENTFD or
+        // the index can be disabled as a whole with: flags = (DATA_NONE|ACTION_TRIGGER), count = 0.
         let mut irq_set = vec_with_array_field::<vfio_irq_set, u32>(0);
         irq_set[0].argsz = mem::size_of::<vfio_irq_set>() as u32;
-        irq_set[0].flags = VFIO_IRQ_SET_ACTION_MASK;
+        irq_set[0].flags = VFIO_IRQ_SET_DATA_NONE | VFIO_IRQ_SET_ACTION_TRIGGER;
         irq_set[0].index = irq_index;
         irq_set[0].start = 0;
-        irq_set[0].count = irq.count;
+        irq_set[0].count = 0;
 
         // Safe as we are the owner of self and irq_set which are valid value
         let ret = unsafe { ioctl_with_ref(self, VFIO_DEVICE_SET_IRQS(), &irq_set[0]) };


### PR DESCRIPTION
The `disable_irq()` function was not properly implemented. This is fixed by this PR, along with a small typo fix.