### PR TITLE
RFC Add a KVM feature gate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,11 +7,15 @@ keywords = ["vfio"]
 license = "Apache-2.0 OR BSD-3-Clause"
 edition = "2018"
 
+[features]
+default = ["kvm"]
+kvm = ["kvm-ioctls", "kvm-bindings"]
+
 [dependencies]
 byteorder = ">=1.2.1"
 log = "0.4"
-kvm-bindings = "~0"
-kvm-ioctls = "~0"
+kvm-bindings = { version = "~0", optional = true }
+kvm-ioctls = { version = "~0", optional = true }
 vfio-bindings = "~0"
 vm-memory = { version = "0.5", features = ["backend-mmap"] }
 vmm-sys-util = "0.8"


### PR DESCRIPTION
We will soon implement MSHV support to this crate. Introduce a KVM
feature gate.

The new feature is enabled by default so existing vfio-iotctls users
don't need to change their code.

