### PR TITLE
vfio_device: remove deprecated with_regions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,5 @@ log = "0.4"
 kvm-bindings = { version = "~0", optional = true }
 kvm-ioctls = { version = "~0", optional = true }
 vfio-bindings = "~0"
-vm-memory = { version = "0.5", features = ["backend-mmap"] }
+vm-memory = { version = "0.6", features = ["backend-mmap"] }
 vmm-sys-util = "0.8"


### PR DESCRIPTION
That function has been deprecated. The warning from rustc suggests the
code use iter instead.

Signed-off-by: Wei Liu <liuwe@microsoft.com>