### PR TITLE
Add MSHV support

### DIFF
--- a/.buildkite/custom-tests.json
+++ b/.buildkite/custom-tests.json
@@ -1,0 +1,14 @@
+{
+  "tests": [
+    {
+      "test_name": "build-mshv",
+      "command": "cargo build --release --no-default-features --features mshv",
+      "platform": ["x86_64"]
+    },
+    {
+      "test_name": "clippy-mshv",
+      "command": "cargo clippy --workspace --bins --examples --benches --no-default-features --features mshv --all-targets -- -D warnings",
+      "platform": ["x86_64"]
+    }
+  ]
+}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 [features]
 default = ["kvm"]
 kvm = ["kvm-ioctls", "kvm-bindings"]
+mshv = ["mshv-ioctls", "mshv-bindings"]
 
 [dependencies]
 byteorder = ">=1.2.1"
@@ -19,3 +20,5 @@ kvm-ioctls = { version = "~0", optional = true }
 vfio-bindings = "~0"
 vm-memory = { version = "0.6", features = ["backend-mmap"] }
 vmm-sys-util = "0.8"
+mshv-bindings = { git = "https://github.com/rust-vmm/mshv", branch = "main", features = ["with-serde", "fam-wrappers"], optional  = true }
+mshv-ioctls = { git = "https://github.com/rust-vmm/mshv", branch = "main", optional  = true }

--- a/src/vfio_device.rs
+++ b/src/vfio_device.rs
@@ -22,11 +22,11 @@ use kvm_bindings::{
 #[cfg(feature = "kvm")]
 use kvm_ioctls::DeviceFd;
 use log::{debug, error, warn};
-#[cfg(feature = "mshv")]
+#[cfg(all(feature = "mshv", not(feature = "kvm")))]
 use mshv_bindings::{
     mshv_device_attr, MSHV_DEV_VFIO_GROUP, MSHV_DEV_VFIO_GROUP_ADD, MSHV_DEV_VFIO_GROUP_DEL,
 };
-#[cfg(feature = "mshv")]
+#[cfg(all(feature = "mshv", not(feature = "kvm")))]
 use mshv_ioctls::DeviceFd;
 use vfio_bindings::bindings::vfio::*;
 use vm_memory::{Address, GuestMemory, GuestMemoryRegion, MemoryRegionAddress};
@@ -243,7 +243,7 @@ impl VfioContainer {
             addr: group_fd_ptr as u64,
         };
 
-        #[cfg(feature = "mshv")]
+        #[cfg(all(feature = "mshv", not(feature = "kvm")))]
         let dev_attr = mshv_device_attr {
             flags: 0,
             group: MSHV_DEV_VFIO_GROUP,
@@ -266,7 +266,7 @@ impl VfioContainer {
             addr: group_fd_ptr as u64,
         };
 
-        #[cfg(feature = "mshv")]
+        #[cfg(all(feature = "mshv", not(feature = "kvm")))]
         let dev_attr = mshv_device_attr {
             flags: 0,
             group: MSHV_DEV_VFIO_GROUP,


### PR DESCRIPTION
These two patches add device fd support for MSHV to vfio-ioctls.

Note that patch is still needs one modification to point to rust-vmm's repository. It is pointing to a local path for MSHV. I will change it once https://github.com/rust-vmm/mshv/pull/11 is merged.