### PR TITLE
deps: Loosen the constraint on vmm-sys-util

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,6 @@ kvm-bindings = { version = "~0", optional = true }
 kvm-ioctls = { version = "~0", optional = true }
 vfio-bindings = "~0"
 vm-memory = { version = "0.6", features = ["backend-mmap"] }
-vmm-sys-util = "0.8"
+vmm-sys-util = ">=0.8.0"
 mshv-bindings = { git = "https://github.com/rust-vmm/mshv", branch = "main", features = ["with-serde", "fam-wrappers"], optional  = true }
 mshv-ioctls = { git = "https://github.com/rust-vmm/mshv", branch = "main", optional  = true }


### PR DESCRIPTION
Pinning the crate to a specific version of the vmm-sys-util prevents
consumer's crates from updating to the latest vmm-sys-util. Instead of
updating vmm-sys-util to 0.9.0, simply loosen the requirement by
allowing any version starting at 0.8.0.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>