### PR TITLE
build: Relax vm-memory dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ log = "0.4"
 kvm-bindings = { version = "~0", optional = true }
 kvm-ioctls = { version = "~0", optional = true }
 vfio-bindings = "~0"
-vm-memory = { version = "0.6", features = ["backend-mmap"] }
+vm-memory = { version = ">=0.6", features = ["backend-mmap"] }
 vmm-sys-util = ">=0.8.0"
 mshv-bindings = { git = "https://github.com/rust-vmm/mshv", branch = "main", features = ["with-serde", "fam-wrappers"], optional  = true }
 mshv-ioctls = { git = "https://github.com/rust-vmm/mshv", branch = "main", optional  = true }


### PR DESCRIPTION
By relaxing the dependency to ">=0.6" this crate can be used in projects
using newer vm-memory without pulling in duplicates of the crate.

Signed-off-by: Rob Bradford <robert.bradford@intel.com>