### PR TITLE
Parse and store VFIO region capabilities

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,5 +63,6 @@ mod vfio_ioctls;
 
 pub use vfio_device::{
     VfioContainer, VfioDevice, VfioError, VfioGroup, VfioIrq, VfioRegion, VfioRegionInfoCap,
-    VfioRegionInfoCapSparseMmap, VfioRegionSparseMmapArea,
+    VfioRegionInfoCapNvlink2Lnkspd, VfioRegionInfoCapNvlink2Ssatgt, VfioRegionInfoCapSparseMmap,
+    VfioRegionInfoCapType, VfioRegionSparseMmapArea,
 };


### PR DESCRIPTION
The parsing of the capabilities was limited to the SPARSE_MMAP capability and was actually incomplete. This PR aims at fixing the incomplete code along with introducing the support for parsing all capability types and expose it to the consumer.

Fixes #34