### PR TITLE
Add unit test cases for vfio-ioctls

### DIFF
--- a/.buildkite/custom-tests.json
+++ b/.buildkite/custom-tests.json
@@ -9,6 +9,16 @@
       "test_name": "clippy-mshv",
       "command": "cargo clippy --workspace --bins --examples --benches --no-default-features --features mshv --all-targets -- -D warnings",
       "platform": ["x86_64"]
+    },
+    {
+      "test_name": "build-nohv",
+      "command": "cargo build --release --no-default-features",
+      "platform": ["x86_64"]
+    },
+    {
+      "test_name": "clippy-nohv",
+      "command": "cargo clippy --workspace --bins --examples --benches --no-default-features --all-targets -- -D warnings",
+      "platform": ["x86_64"]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# Safe wrappers for VFIO
+
+## Design
+
+This repository provides safe wrappers over the
+[VFIO driver framework](https://www.kernel.org/doc/Documentation/vfio.txt).
+
+Many modern systems now provide DMA and interrupt remapping facilities to help ensure I/O devices behave within the boundaries they’ve been allotted. This includes x86 hardware with AMD-Vi and Intel VT-d, POWER systems with Partitionable Endpoints (PEs) and embedded PowerPC systems such as Freescale PAMU. The VFIO driver is an IOMMU/device agnostic framework for exposing direct device access to userspace, in a secure, IOMMU protected environment. In other words, the VFIO framework allows safe, non-privileged, userspace drivers.
+
+Why do we want that? Virtual machines often make use of direct device access (“device assignment”) when configured for the highest possible I/O performance. From a device and host perspective, this simply turns the VM into a userspace driver, with the benefits of significantly reduced latency, higher bandwidth, and direct use of bare-metal device drivers.
+
+Devices are the main target of any I/O driver. Devices typically create a programming interface made up of I/O accesses, interrupts, and DMA. Without going into the details of each of these, DMA is by far the most critical aspect for maintaining a secure environment as allowing a device read-write access to system memory imposes the greatest risk to the overall system integrity.
+
+To help mitigate this risk, many modern IOMMUs now incorporate isolation properties into what was, in many cases, an interface only meant for translation (ie. solving the addressing problems of devices with limited address spaces). With this, devices can now be isolated from each other and from arbitrary memory access, thus allowing things like secure direct assignment of devices into virtual machines.
+
+While for the most part an IOMMU may have device level granularity, any system is susceptible to expose a reduced granularity. The IOMMU API therefore supports a notion of IOMMU groups. A group is a set of devices which is isolated from all other devices in the system. Groups are therefore the unit of ownership used by VFIO.
+
+While the group is the minimum granularity that must be used to ensure secure user access, it’s not necessarily the preferred granularity. In IOMMUs which make use of page tables, it may be possible to share a set of page tables between different groups, reducing the overhead both to the platform (reduced TLB thrashing, reduced duplicate page tables), and to the user (programming only a single set of translations). For this reason, VFIO makes use of a container class, which may hold one or more groups. A container is created by simply opening the /dev/vfio/vfio character device.
+
+## Usage
+This repository provides two crates to use the VFIO framework, please refer to crate documentations for detail information.
+- [vfio-bindings](https://github.com/rust-vmm/vfio-ioctls/tree/ioctls/crates/vfio-bindings): a rust FFI bindings to VFIO generated using [bindgen](https://crates.io/crates/bindgen).
+- [vfio-ioctls](https://github.com/rust-vmm/vfio-ioctls/tree/ioctls/crates/vfio-ioctls): a group of safe wrappers over the [VFIO APIs](https://github.com/torvalds/linux/blob/master/include/uapi/linux/vfio.h).
+
+## License
+
+This code is licensed under Apache-2.0 or BSD-3-Clause.

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 33.8,
+  "coverage_score": 77.4,
   "exclude_path": "",
   "crate_features": ""
 }

--- a/crates/vfio-ioctls/Cargo.toml
+++ b/crates/vfio-ioctls/Cargo.toml
@@ -2,10 +2,12 @@
 name = "vfio-ioctls"
 version = "0.1.0"
 authors = ["The Cloud Hypervisor Authors", "Liu Jiang <gerry@linux.alibaba.com>"]
-description = "Safe wrappers over VFIO ioctls"
-keywords = ["vfio"]
 license = "Apache-2.0 OR BSD-3-Clause"
+description = "Safe wrappers over VFIO ioctls"
+repository = "https://github.com/rust-vmm/vfio"
+readme = "README.md"
 edition = "2018"
+keywords = ["vfio"]
 
 [features]
 default = ["kvm"]

--- a/crates/vfio-ioctls/Cargo.toml
+++ b/crates/vfio-ioctls/Cargo.toml
@@ -17,6 +17,7 @@ byteorder = ">=1.2.1"
 log = "0.4"
 kvm-bindings = { version = "~0", optional = true }
 kvm-ioctls = { version = "~0", optional = true }
+thiserror = ">=1.0"
 vfio-bindings = "~0"
 vm-memory = { version = ">=0.6", features = ["backend-mmap"] }
 vmm-sys-util = ">=0.8.0"

--- a/crates/vfio-ioctls/Cargo.toml
+++ b/crates/vfio-ioctls/Cargo.toml
@@ -14,6 +14,7 @@ mshv = ["mshv-ioctls", "mshv-bindings"]
 
 [dependencies]
 byteorder = ">=1.2.1"
+libc = ">=0.2.39"
 log = "0.4"
 kvm-bindings = { version = "~0", optional = true }
 kvm-ioctls = { version = "~0", optional = true }

--- a/crates/vfio-ioctls/README.md
+++ b/crates/vfio-ioctls/README.md
@@ -1,41 +1,68 @@
-# Crate Name
+# vfio-ioctls
 
 ## Design
 
-TODO: This section should have a high-level design of the crate.
+The [VFIO driver framework](https://www.kernel.org/doc/Documentation/vfio.txt)
+provides unified APIs for direct device access. It is an IOMMU/device-agnostic framework for
+exposing direct device access to user space in a secure, IOMMU-protected environment.
+This framework is used for multiple devices, such as GPUs, network adapters, and compute
+accelerators. With direct device access, virtual machines or user space applications have
+direct access to the physical device.
 
-Some questions that might help in writing this section:
-- What is the purpose of this crate?
-- What are the main components of the crate? How do they interact which each
-  other?
+The VFIO framework is originally developed on Linux system, and later Microsoft HyperVisor
+technology provides a compatible implementation. Therefore the VFIO framework is supported
+by both Linux and Microsoft HyperVisor.
+
+The `vfio-ioctls` crate is a safe wrapper over the VFIO APIs. It provides three classes of structs:
+- `VfioContainer`: a safe wrapper over a VFIO container object, and acts a container object
+  to associate `VfioDevice` objects with IOMMU domains.
+- `VfioDevice`: a wrapper over a VFIO device object, provide methods to access the underlying
+  hardware device.
+- `VfioIrq/VfioRegion`: describes capabilities/resources about a `VfioDevice` object. 
 
 ## Usage
 
-TODO: This section describes how the crate is used.
+The `vfio-ioctls` crate may be used to support following usage scenarios:
+- Direct device assignment to virtual machine based on Linux KVM, with default features.
+- Direct device assignment to virtual machine based on Microsoft HyperVisor, with `--no-default-features --features=mshv`.
+- User mode device drivers, with `--no-default-features`.
 
-Some questions that might help in writing this section:
-- What traits do users need to implement?
-- Does the crate have any default/optional features? What is each feature
-  doing?
-- Is this crate used by other rust-vmm components? If yes, how?
+First, add the following to your Cargo.toml:
+```toml
+vfio-ioctls = "0.1"
+```
+Next, add this to your crate root:
+
+```rust
+extern crate vfio_ioctls;
+```
+
+By default vfio-ioctls has the `kvm` feature enabled. You may turn off the default features by
+`default-features = false`. To enable feature `mshv`,
+```toml
+vfio-ioctls = { version = "0.1", default-features = false, features = ["mshv"]}
+```
+
 
 ## Examples
 
-TODO: Usage examples.
+To create VFIO device object for user mode drivers,
 
 ```rust
-use my_crate;
+use std::sync::Arc;
+use vfio_ioctls::{VfioContainer, VfioDevice};
 
-...
+fn create_vfio_device() {
+  // TODO: change to your device's path
+  let device_path = "/sys/bus/pci/devices/00:03.0";
+  let vfio_container = Arc::new(VfioContainer::new(()).unwrap());
+  let vfio_dev = VfioDevice::new(&Path::new(device_path), vfio_container.clone()).unwrap();
+  let irqs = vfio_dev.max_interrupts();
+
+  assert!(irqs > 0);
+}
 ```
 
 ## License
 
-**!!!NOTICE**: The BSD-3-Clause license is not included in this template.
-The license needs to be manually added because the text of the license file
-also includes the copyright. The copyright can be different for different
-crates. If the crate contains code from CrosVM, the crate must add the
-CrosVM copyright which can be found
-[here](https://chromium.googlesource.com/chromiumos/platform/crosvm/+/master/LICENSE).
-For crates developed from scratch, the copyright is different and depends on
-the contributors.
+This code is licensed under Apache-2.0 or BSD-3-Clause.

--- a/crates/vfio-ioctls/src/lib.rs
+++ b/crates/vfio-ioctls/src/lib.rs
@@ -115,6 +115,14 @@ pub enum VfioError {
     VfioDeviceGetIrqInfo,
     #[error("failed to set vfio device irq")]
     VfioDeviceSetIrq,
+    #[error("failed to enable vfio device irq")]
+    VfioDeviceEnableIrq,
+    #[error("failed to disable vfio device irq")]
+    VfioDeviceDisableIrq,
+    #[error("failed to unmask vfio device irq")]
+    VfioDeviceUnmaskIrq,
+    #[error("failed to trigger vfio device irq")]
+    VfioDeviceTriggerIrq,
 }
 
 /// Specialized version of `Result` for VFIO subsystem.

--- a/crates/vfio-ioctls/src/vfio_device.rs
+++ b/crates/vfio-ioctls/src/vfio_device.rs
@@ -905,7 +905,8 @@ impl VfioDevice {
             .irqs
             .get(&irq_index)
             .ok_or(VfioError::VfioDeviceSetIrq)?;
-        if irq.count == 0 {
+        // Currently the VFIO driver only support MASK/UNMASK INTX, so count is hard-coded to 1.
+        if irq.count == 0 || irq.count != 1 || irq.index != VFIO_PCI_INTX_IRQ_INDEX {
             return Err(VfioError::VfioDeviceSetIrq);
         }
 

--- a/crates/vfio-ioctls/src/vfio_device.rs
+++ b/crates/vfio-ioctls/src/vfio_device.rs
@@ -791,7 +791,7 @@ impl VfioDevice {
             .irqs
             .get(&irq_index)
             .ok_or(VfioError::VfioDeviceSetIrq)?;
-        if irq.count < vector {
+        if irq.count <= vector {
             return Err(VfioError::VfioDeviceSetIrq);
         }
 

--- a/crates/vfio-ioctls/src/vfio_device.rs
+++ b/crates/vfio-ioctls/src/vfio_device.rs
@@ -500,7 +500,7 @@ pub enum VfioRegionInfoCap {
     Nvlink2Lnkspd(VfioRegionInfoCapNvlink2Lnkspd),
 }
 
-/// Information abour VFIO MMIO region.
+/// Information about VFIO MMIO region.
 #[derive(Clone, Debug)]
 pub struct VfioRegion {
     pub(crate) flags: u32,
@@ -509,7 +509,7 @@ pub struct VfioRegion {
     pub(crate) caps: Vec<VfioRegionInfoCap>,
 }
 
-/// Information abour VFIO interrupts.
+/// Information about VFIO interrupts.
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct VfioIrq {
     /// Flags for irq.
@@ -716,7 +716,7 @@ impl AsRawFd for VfioDeviceInfo {
     }
 }
 
-/// Vfio device to access underlying hardware devices.
+/// A safe wrapper over a Vfio device to access underlying hardware device.
 ///
 /// The VFIO device API includes ioctls for describing the device, the I/O regions and their
 /// read/write/mmap offsets on the device descriptor, as well as mechanisms for describing and

--- a/crates/vfio-ioctls/src/vfio_device.rs
+++ b/crates/vfio-ioctls/src/vfio_device.rs
@@ -5,9 +5,7 @@
 
 use std::collections::HashMap;
 use std::ffi::CString;
-use std::fmt;
 use std::fs::{File, OpenOptions};
-use std::io;
 use std::mem::{self, ManuallyDrop};
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 use std::os::unix::prelude::FileExt;
@@ -36,108 +34,7 @@ use vmm_sys_util::ioctl::*;
 
 use crate::fam::vec_with_array_field;
 use crate::vfio_ioctls::*;
-
-#[allow(missing_docs)]
-#[derive(Debug)]
-pub enum VfioError {
-    OpenContainer(io::Error),
-    OpenGroup(io::Error, String),
-    GetGroupStatus,
-    GroupViable,
-    VfioApiVersion,
-    VfioExtension,
-    VfioInvalidType,
-    VfioType1V2,
-    GroupSetContainer,
-    UnsetContainer,
-    ContainerSetIOMMU,
-    GroupGetDeviceFD,
-    SetDeviceAttr(SysError),
-    VfioDeviceGetInfo,
-    VfioDeviceGetRegionInfo(SysError),
-    InvalidPath,
-    IommuDmaMap,
-    IommuDmaUnmap,
-    VfioDeviceGetIrqInfo,
-    VfioDeviceSetIrq,
-}
-pub type Result<T> = std::result::Result<T, VfioError>;
-
-impl fmt::Display for VfioError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            VfioError::OpenContainer(e) => {
-                write!(f, "failed to open /dev/vfio/vfio container: {}", e)
-            }
-            VfioError::OpenGroup(e, ref p) => {
-                write!(f, "failed to open /dev/vfio/{} group: {}", p, e)
-            }
-            VfioError::GetGroupStatus => write!(f, "failed to get Group Status"),
-            VfioError::GroupViable => write!(f, "group is inviable"),
-            VfioError::VfioApiVersion => write!(
-                f,
-                "vfio API version doesn't match with VFIO_API_VERSION defined in vfio-bindings"
-            ),
-            VfioError::VfioExtension => write!(f, "failed to check VFIO extension"),
-            VfioError::VfioInvalidType => write!(f, "invalid VFIO type"),
-            VfioError::VfioType1V2 => {
-                write!(f, "container dones't support VfioType1V2 IOMMU driver type")
-            }
-            VfioError::GroupSetContainer => {
-                write!(f, "failed to add vfio group into vfio container")
-            }
-            VfioError::UnsetContainer => write!(f, "failed to unset vfio container"),
-            VfioError::ContainerSetIOMMU => write!(
-                f,
-                "failed to set container's IOMMU driver type as VfioType1V2"
-            ),
-            VfioError::GroupGetDeviceFD => write!(f, "failed to get vfio device fd"),
-            VfioError::SetDeviceAttr(e) => {
-                write!(f, "failed to set vfio device's attribute: {}", e)
-            }
-            VfioError::VfioDeviceGetInfo => {
-                write!(f, "failed to get vfio device's info or info doesn't match")
-            }
-            VfioError::VfioDeviceGetRegionInfo(e) => {
-                write!(f, "failed to get vfio device's region info: {}", e)
-            }
-            VfioError::InvalidPath => write!(f, "invalid file path"),
-            VfioError::IommuDmaMap => write!(f, "failed to add guest memory map into iommu table"),
-            VfioError::IommuDmaUnmap => {
-                write!(f, "failed to remove guest memory map from iommu table")
-            }
-            VfioError::VfioDeviceGetIrqInfo => write!(f, "failed to get vfio device irq info"),
-            VfioError::VfioDeviceSetIrq => write!(f, "failed to set vfio device irq"),
-        }
-    }
-}
-
-impl std::error::Error for VfioError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        match self {
-            VfioError::OpenContainer(e) => Some(e),
-            VfioError::OpenGroup(e, ref _p) => Some(e),
-            VfioError::GetGroupStatus => None,
-            VfioError::GroupViable => None,
-            VfioError::VfioApiVersion => None,
-            VfioError::VfioExtension => None,
-            VfioError::VfioInvalidType => None,
-            VfioError::VfioType1V2 => None,
-            VfioError::GroupSetContainer => None,
-            VfioError::UnsetContainer => None,
-            VfioError::ContainerSetIOMMU => None,
-            VfioError::GroupGetDeviceFD => None,
-            VfioError::SetDeviceAttr(e) => Some(e),
-            VfioError::VfioDeviceGetInfo => None,
-            VfioError::VfioDeviceGetRegionInfo(e) => Some(e),
-            VfioError::InvalidPath => None,
-            VfioError::IommuDmaMap => None,
-            VfioError::IommuDmaUnmap => None,
-            VfioError::VfioDeviceGetIrqInfo => None,
-            VfioError::VfioDeviceSetIrq => None,
-        }
-    }
-}
+use crate::{Result, VfioError};
 
 #[repr(C)]
 #[derive(Debug, Default)]

--- a/crates/vfio-ioctls/src/vfio_ioctls.rs
+++ b/crates/vfio-ioctls/src/vfio_ioctls.rs
@@ -14,8 +14,8 @@ use std::os::unix::io::AsRawFd;
 use vfio_bindings::bindings::vfio::*;
 use vmm_sys_util::errno::Error as SysError;
 
-use crate::vfio_device::vfio_region_info_with_cap;
-use crate::{Result, VfioContainer, VfioDevice, VfioError};
+use crate::vfio_device::{vfio_region_info_with_cap, VfioDeviceInfo};
+use crate::{Result, VfioContainer, VfioDevice, VfioError, VfioGroup};
 
 ioctl_io_nr!(VFIO_GET_API_VERSION, VFIO_TYPE, VFIO_BASE);
 ioctl_io_nr!(VFIO_CHECK_EXTENSION, VFIO_TYPE, VFIO_BASE + 1);
@@ -44,18 +44,17 @@ ioctl_io_nr!(VFIO_IOMMU_UNMAP_DMA, VFIO_TYPE, VFIO_BASE + 14);
 ioctl_io_nr!(VFIO_IOMMU_ENABLE, VFIO_TYPE, VFIO_BASE + 15);
 ioctl_io_nr!(VFIO_IOMMU_DISABLE, VFIO_TYPE, VFIO_BASE + 16);
 
+#[cfg(not(test))]
 // Safety:
 // - absolutely trust the underlying kernel
 // - absolutely trust data returned by the underlying kernel
 // - assume kernel will return error if caller passes in invalid file handle, parameter or buffer.
 pub(crate) mod vfio_syscall {
+    use super::*;
     use std::os::unix::io::FromRawFd;
     use vmm_sys_util::ioctl::{
         ioctl, ioctl_with_mut_ref, ioctl_with_ptr, ioctl_with_ref, ioctl_with_val,
     };
-    use super::*;
-    use crate::vfio_device::VfioDeviceInfo;
-    use crate::VfioGroup;
 
     pub(crate) fn check_api_version(container: &VfioContainer) -> i32 {
         // Safe as file is vfio container fd and ioctl is defined by kernel.
@@ -241,6 +240,248 @@ pub(crate) mod vfio_syscall {
             } else {
                 Ok(())
             }
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod vfio_syscall {
+    use super::*;
+    use vfio_bindings::bindings::vfio::{vfio_device_info, VFIO_IRQ_INFO_EVENTFD};
+    use vmm_sys_util::tempfile::TempFile;
+
+    pub(crate) fn check_api_version(_container: &VfioContainer) -> i32 {
+        VFIO_API_VERSION as i32
+    }
+
+    pub(crate) fn check_extension(_container: &VfioContainer, val: u32) -> Result<u32> {
+        if val == VFIO_TYPE1v2_IOMMU {
+            Ok(1)
+        } else {
+            Err(VfioError::VfioExtension)
+        }
+    }
+
+    pub(crate) fn set_iommu(_container: &VfioContainer, _val: u32) -> Result<()> {
+        Ok(())
+    }
+
+    pub(crate) fn map_dma(
+        _container: &VfioContainer,
+        dma_map: &vfio_iommu_type1_dma_map,
+    ) -> Result<()> {
+        if dma_map.iova == 0x1000 {
+            Ok(())
+        } else {
+            Err(VfioError::IommuDmaMap)
+        }
+    }
+
+    pub(crate) fn unmap_dma(
+        _container: &VfioContainer,
+        dma_map: &mut vfio_iommu_type1_dma_unmap,
+    ) -> Result<()> {
+        if dma_map.iova == 0x1000 {
+            Ok(())
+        } else {
+            Err(VfioError::IommuDmaUnmap)
+        }
+    }
+
+    pub(crate) fn get_group_status(
+        _file: &File,
+        group_status: &mut vfio_group_status,
+    ) -> Result<()> {
+        group_status.flags = VFIO_GROUP_FLAGS_VIABLE;
+        Ok(())
+    }
+
+    pub(crate) fn get_group_device_fd(_group: &VfioGroup, _path: &CStr) -> Result<File> {
+        let tmp_file = TempFile::new().unwrap();
+        let device = File::open(tmp_file.as_path()).unwrap();
+
+        Ok(device)
+    }
+
+    pub(crate) fn set_group_container(group: &VfioGroup, container: &VfioContainer) -> Result<()> {
+        if group.as_raw_fd() >= 0 && container.as_raw_fd() >= 0 {
+            Ok(())
+        } else {
+            Err(VfioError::GroupSetContainer)
+        }
+    }
+
+    pub(crate) fn unset_group_container(
+        group: &VfioGroup,
+        container: &VfioContainer,
+    ) -> Result<()> {
+        if group.as_raw_fd() >= 0 && container.as_raw_fd() >= 0 {
+            Ok(())
+        } else {
+            Err(VfioError::GroupSetContainer)
+        }
+    }
+
+    pub(crate) fn get_device_info(_file: &File, dev_info: &mut vfio_device_info) -> Result<()> {
+        dev_info.flags = VFIO_DEVICE_FLAGS_PCI;
+        dev_info.num_regions = VFIO_PCI_CONFIG_REGION_INDEX + 1;
+        dev_info.num_irqs = VFIO_PCI_MSIX_IRQ_INDEX + 1;
+        Ok(())
+    }
+
+    #[allow(clippy::if_same_then_else)]
+    pub(crate) fn set_device_irqs(_device: &VfioDevice, irq_sets: &[vfio_irq_set]) -> Result<()> {
+        if irq_sets.is_empty()
+            || irq_sets[0].argsz as usize > irq_sets.len() * size_of::<vfio_irq_set>()
+        {
+            Err(VfioError::VfioDeviceSetIrq)
+        } else {
+            let irq_set = &irq_sets[0];
+            if irq_set.flags == VFIO_IRQ_SET_DATA_EVENTFD | VFIO_IRQ_SET_ACTION_TRIGGER
+                && irq_set.index == 0
+                && irq_set.count == 0
+            {
+                Err(VfioError::VfioDeviceSetIrq)
+            } else if irq_set.flags == VFIO_IRQ_SET_DATA_NONE | VFIO_IRQ_SET_ACTION_TRIGGER
+                && irq_set.index == 0
+                && irq_set.count == 0
+            {
+                Err(VfioError::VfioDeviceSetIrq)
+            } else if irq_set.flags == VFIO_IRQ_SET_DATA_NONE | VFIO_IRQ_SET_ACTION_UNMASK
+                && irq_set.index == 1
+                && irq_set.count == 1
+            {
+                Err(VfioError::VfioDeviceSetIrq)
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    pub(crate) fn reset(_device: &VfioDevice) -> i32 {
+        0
+    }
+
+    pub(crate) fn get_device_region_info(
+        _dev_info: &VfioDeviceInfo,
+        reg_info: &mut vfio_region_info,
+    ) -> Result<()> {
+        match reg_info.index {
+            0 => {
+                reg_info.flags = 0;
+                reg_info.size = 0x1000;
+                reg_info.offset = 0x10000;
+            }
+            1 => {
+                reg_info.argsz = 88;
+                reg_info.flags = VFIO_REGION_INFO_FLAG_CAPS;
+                reg_info.size = 0x2000;
+                reg_info.offset = 0x20000;
+            }
+            idx if (2..7).contains(&idx) => {
+                reg_info.flags = 0;
+                reg_info.size = (idx as u64 + 1) * 0x1000;
+                reg_info.offset = (idx as u64 + 1) * 0x10000;
+            }
+            7 => {
+                return Err(VfioError::VfioDeviceGetRegionInfo(SysError::new(
+                    libc::EINVAL,
+                )))
+            }
+            _ => panic!("invalid device region index"),
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn get_device_region_info_cap(
+        _dev_info: &VfioDeviceInfo,
+        reg_infos: &mut [vfio_region_info_with_cap],
+    ) -> Result<()> {
+        if reg_infos.is_empty()
+            || reg_infos[0].region_info.argsz as usize
+                > reg_infos.len() * size_of::<vfio_region_info>()
+        {
+            return Err(VfioError::VfioDeviceGetRegionInfo(SysError::new(
+                libc::EINVAL,
+            )));
+        }
+
+        let reg_info = &mut reg_infos[0];
+        match reg_info.region_info.index {
+            1 => {
+                reg_info.region_info.cap_offset = 32;
+                let header = unsafe {
+                    &mut *((reg_info as *mut vfio_region_info_with_cap as *mut u8).add(32)
+                        as *mut vfio_info_cap_header)
+                };
+                header.id = VFIO_REGION_INFO_CAP_MSIX_MAPPABLE as u16;
+                header.next = 40;
+
+                let header = unsafe {
+                    &mut *((header as *mut vfio_info_cap_header as *mut u8).add(8)
+                        as *mut vfio_region_info_cap_type)
+                };
+                header.header.id = VFIO_REGION_INFO_CAP_TYPE as u16;
+                header.header.next = 56;
+                header.type_ = 0x5;
+                header.subtype = 0x6;
+
+                let header = unsafe {
+                    &mut *((header as *mut vfio_region_info_cap_type as *mut u8).add(16)
+                        as *mut vfio_region_info_cap_sparse_mmap)
+                };
+                header.header.id = VFIO_REGION_INFO_CAP_SPARSE_MMAP as u16;
+                header.header.next = 4;
+                header.nr_areas = 1;
+
+                let mmap = unsafe {
+                    &mut *((header as *mut vfio_region_info_cap_sparse_mmap as *mut u8).add(16)
+                        as *mut vfio_region_sparse_mmap_area)
+                };
+                mmap.size = 0x3;
+                mmap.offset = 0x4;
+            }
+            _ => panic!("invalid device region index"),
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn get_device_irq_info(
+        _dev_info: &VfioDeviceInfo,
+        irq_info: &mut vfio_irq_info,
+    ) -> Result<()> {
+        match irq_info.index {
+            0 => {
+                irq_info.flags = VFIO_IRQ_INFO_MASKABLE;
+                irq_info.count = 1;
+            }
+            1 => {
+                irq_info.flags = VFIO_IRQ_INFO_EVENTFD;
+                irq_info.count = 32;
+            }
+            2 => {
+                irq_info.flags = VFIO_IRQ_INFO_EVENTFD;
+                irq_info.count = 2048;
+            }
+            3 => {
+                return Err(VfioError::VfioDeviceGetRegionInfo(SysError::new(
+                    libc::EINVAL,
+                )))
+            }
+            _ => panic!("invalid device irq index"),
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn create_dev_info_for_test() -> vfio_device_info {
+        vfio_device_info {
+            argsz: 0,
+            flags: 0,
+            num_regions: 2,
+            num_irqs: 4,
         }
     }
 }

--- a/crates/vfio-ioctls/src/vfio_ioctls.rs
+++ b/crates/vfio-ioctls/src/vfio_ioctls.rs
@@ -6,7 +6,16 @@
 #![allow(non_camel_case_types)]
 #![allow(non_snake_case)]
 
+use std::ffi::CStr;
+use std::fs::File;
+use std::mem::size_of;
+use std::os::unix::io::AsRawFd;
+
 use vfio_bindings::bindings::vfio::*;
+use vmm_sys_util::errno::Error as SysError;
+
+use crate::vfio_device::vfio_region_info_with_cap;
+use crate::{Result, VfioContainer, VfioDevice, VfioError};
 
 ioctl_io_nr!(VFIO_GET_API_VERSION, VFIO_TYPE, VFIO_BASE);
 ioctl_io_nr!(VFIO_CHECK_EXTENSION, VFIO_TYPE, VFIO_BASE + 1);
@@ -34,6 +43,207 @@ ioctl_io_nr!(VFIO_IOMMU_MAP_DMA, VFIO_TYPE, VFIO_BASE + 13);
 ioctl_io_nr!(VFIO_IOMMU_UNMAP_DMA, VFIO_TYPE, VFIO_BASE + 14);
 ioctl_io_nr!(VFIO_IOMMU_ENABLE, VFIO_TYPE, VFIO_BASE + 15);
 ioctl_io_nr!(VFIO_IOMMU_DISABLE, VFIO_TYPE, VFIO_BASE + 16);
+
+// Safety:
+// - absolutely trust the underlying kernel
+// - absolutely trust data returned by the underlying kernel
+// - assume kernel will return error if caller passes in invalid file handle, parameter or buffer.
+pub(crate) mod vfio_syscall {
+    use std::os::unix::io::FromRawFd;
+    use vmm_sys_util::ioctl::{
+        ioctl, ioctl_with_mut_ref, ioctl_with_ptr, ioctl_with_ref, ioctl_with_val,
+    };
+    use super::*;
+    use crate::vfio_device::VfioDeviceInfo;
+    use crate::VfioGroup;
+
+    pub(crate) fn check_api_version(container: &VfioContainer) -> i32 {
+        // Safe as file is vfio container fd and ioctl is defined by kernel.
+        unsafe { ioctl(container, VFIO_GET_API_VERSION()) }
+    }
+
+    pub(crate) fn check_extension(container: &VfioContainer, val: u32) -> Result<u32> {
+        // Safe as file is vfio container and make sure val is valid.
+        let ret = unsafe { ioctl_with_val(container, VFIO_CHECK_EXTENSION(), val.into()) };
+        if ret < 0 {
+            Err(VfioError::VfioExtension)
+        } else {
+            Ok(ret as u32)
+        }
+    }
+
+    pub(crate) fn set_iommu(container: &VfioContainer, val: u32) -> Result<()> {
+        // Safe as file is vfio container and make sure val is valid.
+        let ret = unsafe { ioctl_with_val(container, VFIO_SET_IOMMU(), val.into()) };
+        if ret < 0 {
+            Err(VfioError::ContainerSetIOMMU)
+        } else {
+            Ok(())
+        }
+    }
+
+    pub(crate) fn map_dma(
+        container: &VfioContainer,
+        dma_map: &vfio_iommu_type1_dma_map,
+    ) -> Result<()> {
+        // Safe as file is vfio container, dma_map is constructed by us, and
+        // we check the return value
+        let ret = unsafe { ioctl_with_ref(container, VFIO_IOMMU_MAP_DMA(), dma_map) };
+        if ret != 0 {
+            Err(VfioError::IommuDmaMap)
+        } else {
+            Ok(())
+        }
+    }
+
+    pub(crate) fn unmap_dma(
+        container: &VfioContainer,
+        dma_map: &mut vfio_iommu_type1_dma_unmap,
+    ) -> Result<()> {
+        // Safe as file is vfio container, dma_unmap is constructed by us, and
+        // we check the return value
+        let ret = unsafe { ioctl_with_ref(container, VFIO_IOMMU_UNMAP_DMA(), dma_map) };
+        if ret != 0 {
+            Err(VfioError::IommuDmaUnmap)
+        } else {
+            Ok(())
+        }
+    }
+
+    pub(crate) fn get_group_status(
+        file: &File,
+        group_status: &mut vfio_group_status,
+    ) -> Result<()> {
+        // Safe as we are the owner of group and group_status which are valid value.
+        let ret = unsafe { ioctl_with_mut_ref(file, VFIO_GROUP_GET_STATUS(), group_status) };
+        if ret < 0 {
+            Err(VfioError::GetGroupStatus)
+        } else {
+            Ok(())
+        }
+    }
+
+    pub(crate) fn get_group_device_fd(group: &VfioGroup, path: &CStr) -> Result<File> {
+        // Safe as we are the owner of self and path_ptr which are valid value.
+        let fd = unsafe { ioctl_with_ptr(group, VFIO_GROUP_GET_DEVICE_FD(), path.as_ptr()) };
+        if fd < 0 {
+            Err(VfioError::GroupGetDeviceFD)
+        } else {
+            // Safe as fd is valid FD
+            Ok(unsafe { File::from_raw_fd(fd) })
+        }
+    }
+
+    pub(crate) fn set_group_container(group: &VfioGroup, container: &VfioContainer) -> Result<()> {
+        let container_raw_fd = container.as_raw_fd();
+        // Safe as we are the owner of group and container_raw_fd which are valid value,
+        // and we verify the ret value
+        let ret = unsafe { ioctl_with_ref(group, VFIO_GROUP_SET_CONTAINER(), &container_raw_fd) };
+        if ret < 0 {
+            Err(VfioError::GroupSetContainer)
+        } else {
+            Ok(())
+        }
+    }
+
+    pub(crate) fn unset_group_container(
+        group: &VfioGroup,
+        container: &VfioContainer,
+    ) -> Result<()> {
+        let container_raw_fd = container.as_raw_fd();
+        // Safe as we are the owner of self and container_raw_fd which are valid value.
+        let ret = unsafe { ioctl_with_ref(group, VFIO_GROUP_UNSET_CONTAINER(), &container_raw_fd) };
+        if ret < 0 {
+            Err(VfioError::GroupSetContainer)
+        } else {
+            Ok(())
+        }
+    }
+
+    pub(crate) fn get_device_info(file: &File, dev_info: &mut vfio_device_info) -> Result<()> {
+        // Safe as we are the owner of dev and dev_info which are valid value,
+        // and we verify the return value.
+        let ret = unsafe { ioctl_with_mut_ref(file, VFIO_DEVICE_GET_INFO(), dev_info) };
+        if ret < 0 {
+            Err(VfioError::VfioDeviceGetInfo)
+        } else {
+            Ok(())
+        }
+    }
+
+    pub(crate) fn set_device_irqs(device: &VfioDevice, irq_set: &[vfio_irq_set]) -> Result<()> {
+        if irq_set.is_empty()
+            || irq_set[0].argsz as usize > irq_set.len() * size_of::<vfio_irq_set>()
+        {
+            Err(VfioError::VfioDeviceSetIrq)
+        } else {
+            // Safe as we are the owner of self and irq_set which are valid value
+            let ret = unsafe { ioctl_with_ref(device, VFIO_DEVICE_SET_IRQS(), &irq_set[0]) };
+            if ret < 0 {
+                Err(VfioError::VfioDeviceSetIrq)
+            } else {
+                Ok(())
+            }
+        }
+    }
+
+    pub(crate) fn reset(device: &VfioDevice) -> i32 {
+        // Safe as file is vfio device
+        unsafe { ioctl(device, VFIO_DEVICE_RESET()) }
+    }
+
+    pub(crate) fn get_device_irq_info(
+        dev_info: &VfioDeviceInfo,
+        irq_info: &mut vfio_irq_info,
+    ) -> Result<()> {
+        // Safe as we are the owner of dev and irq_info which are valid value
+        let ret = unsafe { ioctl_with_mut_ref(dev_info, VFIO_DEVICE_GET_IRQ_INFO(), irq_info) };
+        if ret < 0 {
+            Err(VfioError::VfioDeviceGetRegionInfo(SysError::new(-ret)))
+        } else {
+            Ok(())
+        }
+    }
+
+    pub(crate) fn get_device_region_info(
+        dev_info: &VfioDeviceInfo,
+        reg_info: &mut vfio_region_info,
+    ) -> Result<()> {
+        // Safe as we are the owner of dev and region_info which are valid value
+        // and we verify the return value.
+        let ret = unsafe { ioctl_with_mut_ref(dev_info, VFIO_DEVICE_GET_REGION_INFO(), reg_info) };
+        if ret < 0 {
+            Err(VfioError::VfioDeviceGetRegionInfo(SysError::new(-ret)))
+        } else {
+            Ok(())
+        }
+    }
+
+    pub(crate) fn get_device_region_info_cap(
+        dev_info: &VfioDeviceInfo,
+        reg_infos: &mut [vfio_region_info_with_cap],
+    ) -> Result<()> {
+        if reg_infos.is_empty()
+            || reg_infos[0].region_info.argsz as usize
+                > reg_infos.len() * size_of::<vfio_region_info>()
+        {
+            Err(VfioError::VfioDeviceGetRegionInfo(SysError::new(
+                libc::EINVAL,
+            )))
+        } else {
+            // Safe as we are the owner of dev and region_info which are valid value,
+            // and we verify the return value.
+            let ret = unsafe {
+                ioctl_with_mut_ref(dev_info, VFIO_DEVICE_GET_REGION_INFO(), &mut reg_infos[0])
+            };
+            if ret < 0 {
+                Err(VfioError::VfioDeviceGetRegionInfo(SysError::new(-ret)))
+            } else {
+                Ok(())
+            }
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/vfio-ioctls/src/vfio_ioctls.rs
+++ b/crates/vfio-ioctls/src/vfio_ioctls.rs
@@ -34,3 +34,26 @@ ioctl_io_nr!(VFIO_IOMMU_MAP_DMA, VFIO_TYPE, VFIO_BASE + 13);
 ioctl_io_nr!(VFIO_IOMMU_UNMAP_DMA, VFIO_TYPE, VFIO_BASE + 14);
 ioctl_io_nr!(VFIO_IOMMU_ENABLE, VFIO_TYPE, VFIO_BASE + 15);
 ioctl_io_nr!(VFIO_IOMMU_DISABLE, VFIO_TYPE, VFIO_BASE + 16);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_vfio_ioctl_code() {
+        assert_eq!(VFIO_GET_API_VERSION(), 15204);
+        assert_eq!(VFIO_CHECK_EXTENSION(), 15205);
+        assert_eq!(VFIO_SET_IOMMU(), 15206);
+        assert_eq!(VFIO_GROUP_GET_STATUS(), 15207);
+        assert_eq!(VFIO_GROUP_SET_CONTAINER(), 15208);
+        assert_eq!(VFIO_GROUP_UNSET_CONTAINER(), 15209);
+        assert_eq!(VFIO_GROUP_GET_DEVICE_FD(), 15210);
+        assert_eq!(VFIO_DEVICE_GET_INFO(), 15211);
+        assert_eq!(VFIO_DEVICE_GET_REGION_INFO(), 15212);
+        assert_eq!(VFIO_DEVICE_GET_IRQ_INFO(), 15213);
+        assert_eq!(VFIO_DEVICE_SET_IRQS(), 15214);
+        assert_eq!(VFIO_DEVICE_RESET(), 15215);
+        assert_eq!(VFIO_DEVICE_IOEVENTFD(), 15220);
+        assert_eq!(VFIO_IOMMU_DISABLE(), 15220);
+    }
+}


### PR DESCRIPTION
This PR prepares for publishing the vfio-ioctls by:
1) add a mock test framework
2) add unit test cases
3) support user mode device driver in addition to kvm/mshv, same goal as #33 
4) improve README.md